### PR TITLE
Add Telemetry Drawer for Electron React frontend

### DIFF
--- a/electron-frontend/src/App.tsx
+++ b/electron-frontend/src/App.tsx
@@ -1,7 +1,13 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './style.css';
+import { TelemetryProvider, useTelemetry } from './telemetry/TelemetryContext';
+import { TelemetryDrawer } from './telemetry/TelemetryDrawer';
+import { TelemetryToggle } from './telemetry/TelemetryToggle';
 
-const App: React.FC = () => {
+const Dashboard: React.FC = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const { publish } = useTelemetry();
+
   useEffect(() => {
     // legacy renderer logic
     const script = document.createElement('script');
@@ -11,6 +17,17 @@ const App: React.FC = () => {
       document.body.removeChild(script);
     };
   }, []);
+
+  useEffect(() => {
+    // sample metrics
+    const interval = setInterval(() => {
+      publish({ group: 'System', key: 'CPU Load', value: `${Math.floor(Math.random()*100)} %`, ts: Date.now() });
+      publish({ group: 'YOLOv8', key: 'Inference Latency', value: `${Math.floor(Math.random()*50)+20} ms`, ts: Date.now() });
+      publish({ group: 'Decoder', key: 'Frame Rate', value: `${29 + Math.floor(Math.random()*3)} fps`, ts: Date.now() });
+      publish({ group: 'Tracker', key: 'Active Targets', value: Math.floor(Math.random()*5), ts: Date.now() });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [publish]);
 
   return (
     <div id="app-container">
@@ -109,8 +126,17 @@ const App: React.FC = () => {
         <span id="connection-status">Status: Disconnected</span>
         <button id="clear-stats-btn" className="footer-button">Clear Stats</button>
       </footer>
+      <TelemetryToggle onToggle={() => setDrawerOpen(o => !o)} />
+      <TelemetryDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
     </div>
   );
 };
 
+const App: React.FC = () => (
+  <TelemetryProvider>
+    <Dashboard />
+  </TelemetryProvider>
+);
+
 export default App;
+

--- a/electron-frontend/src/telemetry/TelemetryContext.tsx
+++ b/electron-frontend/src/telemetry/TelemetryContext.tsx
@@ -1,0 +1,38 @@
+import React, {createContext, useContext, useState} from 'react';
+
+export type TelemetryEntry = {
+  group: string;
+  key: string;
+  value: string | number;
+  ts: number; // epoch ms
+};
+
+interface TelemetryContextValue {
+  entries: TelemetryEntry[];
+  publish: (entry: TelemetryEntry) => void;
+}
+
+const TelemetryContext = createContext<TelemetryContextValue>({
+  entries: [],
+  publish: () => {},
+});
+
+export const TelemetryProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const [entries, setEntries] = useState<TelemetryEntry[]>([]);
+
+  const publish = (entry: TelemetryEntry) => {
+    setEntries(prev => {
+      // replace existing entry with same group+key
+      const filtered = prev.filter(e => !(e.group === entry.group && e.key === entry.key));
+      return [...filtered, entry];
+    });
+  };
+
+  return (
+    <TelemetryContext.Provider value={{entries, publish}}>
+      {children}
+    </TelemetryContext.Provider>
+  );
+};
+
+export const useTelemetry = () => useContext(TelemetryContext);

--- a/electron-frontend/src/telemetry/TelemetryDrawer.tsx
+++ b/electron-frontend/src/telemetry/TelemetryDrawer.tsx
@@ -1,0 +1,115 @@
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { useTelemetry, TelemetryEntry } from './TelemetryContext';
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 999;
+`;
+
+const Drawer = styled.div<{open: boolean}>`
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 320px;
+  height: 100vh;
+  background: #2b2b2b;
+  box-shadow: -2px 0 8px rgba(0,0,0,0.4);
+  transition: transform 0.3s ease;
+  transform: translateX(${props => (props.open ? '0' : '100%')});
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled.div`
+  padding: 10px;
+  border-bottom: 1px solid #444;
+  font-weight: bold;
+`;
+
+const SearchInput = styled.input`
+  margin: 10px;
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #1e1e1e;
+  color: #fff;
+`;
+
+const GroupHeader = styled.div`
+  padding: 4px 10px;
+  background: #383838;
+  font-weight: bold;
+`;
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 10px;
+  font-size: 0.9em;
+  &:hover {
+    background: #444;
+  }
+`;
+
+const Value = styled.span`
+  font-family: monospace;
+`;
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const TelemetryDrawer: React.FC<DrawerProps> = ({open, onClose}) => {
+  const { entries } = useTelemetry();
+  const [filter, setFilter] = useState('');
+
+  const grouped = useMemo(() => {
+    const map: Record<string, TelemetryEntry[]> = {};
+    entries.forEach(e => {
+      if (filter && !e.key.toLowerCase().includes(filter.toLowerCase())) return;
+      if (!map[e.group]) map[e.group] = [];
+      map[e.group].push(e);
+    });
+    return map;
+  }, [entries, filter]);
+
+  const now = Date.now();
+
+  return (
+    <>
+      {open && <Overlay onClick={onClose} />}
+      <Drawer open={open}>
+        <Header>Telemetry</Header>
+        <SearchInput
+          placeholder="Filter keys..."
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+        />
+        <div style={{overflowY: 'auto', flex: 1}}>
+          {Object.entries(grouped).map(([group, items]) => (
+            <div key={group}>
+              <GroupHeader>{group}</GroupHeader>
+              {items.map(item => (
+                <Row key={`${group}-${item.key}`}>
+                  <span>{item.key}</span>
+                  <Value>{item.value}</Value>
+                  <span style={{marginLeft: '8px', fontSize: '0.8em', opacity: 0.6}}>
+                    {Math.round((now - item.ts)/1000)}s ago
+                  </span>
+                </Row>
+              ))}
+            </div>
+          ))}
+        </div>
+      </Drawer>
+    </>
+  );
+};

--- a/electron-frontend/src/telemetry/TelemetryToggle.tsx
+++ b/electron-frontend/src/telemetry/TelemetryToggle.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translate(50%, -50%);
+  background: #2b2b2b;
+  border-radius: 4px 0 0 4px;
+  border: 1px solid #444;
+  color: #fff;
+  padding: 8px 10px;
+  cursor: pointer;
+  z-index: 1001;
+  &:hover {
+    background: #383838;
+  }
+`;
+
+interface ToggleProps {
+  onToggle: () => void;
+}
+
+export const TelemetryToggle: React.FC<ToggleProps> = ({ onToggle }) => (
+  <Button onClick={onToggle}>
+    ≡
+  </Button>
+);


### PR DESCRIPTION
## Summary
- add TelemetryContext with publish helper
- implement TelemetryDrawer and TelemetryToggle components with styled‑components
- wire drawer and sample telemetry feed into `App`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881b329484883238474745333429382