### PR TITLE
Occupancy Publishing: MQTT + InfluxDB + HomeSeer

### DIFF
--- a/config.py
+++ b/config.py
@@ -287,6 +287,28 @@ class AppConfig:
                 "match_thresh": self.MATCH_THRESH,
                 "frame_rate": 30, # Default frame rate for tracking
             }
+
+    @dataclass
+    class IntegrationsSettings:
+        """Integration settings for MQTT + Influx occupancy publishing"""
+        ENABLE_OCCUPANCY_PUBLISH: bool = True
+        HEARTBEAT_SEC: int = 60
+
+        # MQTT
+        BASE_TOPIC: str = "noesis/occupancy"
+        STATUS_TOPIC: str = "noesis/status"
+        MQTT_HOST: str = "127.0.0.1"
+        MQTT_PORT: int = 1883
+        MQTT_USERNAME: str = "noesis"
+        MQTT_PASSWORD: str = "damosquittopass"
+        MQTT_QOS: int = 1
+        MQTT_RETAIN: bool = True
+
+        # InfluxDB v2
+        INFLUX_URL: str = "http://127.0.0.1:8086"
+        INFLUX_ORG: str = "Lambda"
+        INFLUX_TOKEN: str = "mfVNLy3JpTXwuX-_ZN9r5dbXzLaXCW9F6isbA10i4r-tNE3aigcF1UqmMdDtPKskDhKk7-6iKtoIOEphpB14wA=="
+        INFLUX_BUCKET_RAW: str = "noesis_raw"
     
     @dataclass
     class OutputSettings:
@@ -314,6 +336,7 @@ class AppConfig:
     output: OutputSettings = field(default_factory=OutputSettings)
     websocket: WebSocketSettings = field(default_factory=WebSocketSettings)
     tracking: TrackingSettings = field(default_factory=TrackingSettings)
+    integrations: IntegrationsSettings = field(default_factory=IntegrationsSettings)
     
     def get_camera_count(self) -> int:
         """Calculate total number of camera sources configured."""
@@ -466,7 +489,17 @@ def save_config_to_file(config: AppConfig, config_file: str) -> bool:
         # Create configuration data structure for serialization
         config_data = {}
         
-        for section_name in ["app", "cameras", "processing", "models", "visualization", "output", "websocket", "tracking"]:
+        for section_name in [
+            "app",
+            "cameras",
+            "processing",
+            "models",
+            "visualization",
+            "output",
+            "websocket",
+            "tracking",
+            "integrations",
+        ]:
             section = getattr(config, section_name)
             section_data = {}
             

--- a/deepstream_video_pipeline.py
+++ b/deepstream_video_pipeline.py
@@ -887,6 +887,12 @@ class DeepStreamVideoPipeline:
         ds_index = int(frame_meta.source_id)
         sensor_id = self.sensor_id_by_source_idx.get(ds_index, ds_index)
         
+        # Keep a copy of previous occupancy to detect vacates
+        try:
+            prev_occupancy = dict(self.live_tracking_state.get(sensor_id, {}).get('occupancy', {}))
+        except Exception:
+            prev_occupancy = {}
+
         l_obj = frame_meta.obj_meta_list
         while l_obj:
             obj = pyds.NvDsObjectMeta.cast(l_obj.data)  # type: ignore
@@ -982,6 +988,44 @@ class DeepStreamVideoPipeline:
             except StopIteration:
                 break
         
+        # Publish occupancy deltas to integrations (MQTT/Influx)
+        try:
+            publisher = getattr(self, 'occupancy_publisher', None)
+            if publisher is not None and occupancy is not None:
+                # Publish current counts (rooms seen this frame)
+                first_flag = getattr(self, '_occ_pub_first', True)
+                for zone, cnt in occupancy.items():
+                    try:
+                        room_id = str(zone).strip()
+                        publisher.publish_state(room_id=room_id, occupied=(int(cnt) > 0), count=int(cnt), ts_ns=int(time.time_ns()))
+                        if first_flag:
+                            try:
+                                print(f"📡 Occupancy publish: {room_id} -> {int(cnt)}")
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+                # Publish vacates for zones seen previously but not this frame
+                for zone in set(prev_occupancy.keys()) - set(occupancy.keys()):
+                    try:
+                        room_id = str(zone).strip()
+                        publisher.publish_state(room_id=room_id, occupied=False, count=0, ts_ns=int(time.time_ns()))
+                        if first_flag:
+                            try:
+                                print(f"📡 Occupancy publish: {room_id} -> 0 (vacate)")
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+                if first_flag:
+                    try:
+                        self._occ_pub_first = False
+                    except Exception:
+                        pass
+        except Exception:
+            # Never allow publishing issues to affect the pipeline
+            pass
+
         # Update live tracking state for this specific stream
         if sensor_id in self.live_tracking_state:
             self.live_tracking_state[sensor_id]['active_tracks'] = active_tracks

--- a/docs/integrations/occupancy_mqtt_influx.md
+++ b/docs/integrations/occupancy_mqtt_influx.md
@@ -1,0 +1,69 @@
+Noesis Occupancy → MQTT + InfluxDB + HomeSeer
+
+Overview
+- Publishes retained MQTT topics for room occupancy for HomeSeer (mcsMQTT) automations.
+- Writes the same state changes to InfluxDB v2 for history (bucket `noesis_raw`).
+- Heartbeat refreshes retained MQTT state; Influx writes only on change.
+
+See Also
+- For a step-by-step playbook and a reusable pattern to add future integrations or stats, refer to `docs/reference/Integrations_Playbook.md`.
+
+MQTT Topics
+- Base: `noesis/occupancy/<room>` where `<room>` is a slug from ROI/zone name.
+- `noesis/occupancy/<room>/occupied`: "0" or "1" (retained, QoS 1)
+- `noesis/occupancy/<room>/count`: "0..N" (retained, QoS 1)
+- `noesis/occupancy/<room>`: JSON `{ts, occupied, count}` (retained, QoS 1)
+- Status: `noesis/status`: "online"/"offline" (retained)
+
+InfluxDB
+- Measurement: `occupancy`
+- Tags: `room_id=<room>`
+- Fields: `occupied` (int), `count` (int)
+- Writes to bucket: `noesis_raw`
+
+Config (config.py → AppConfig.integrations)
+- `ENABLE_OCCUPANCY_PUBLISH` (bool)
+- `HEARTBEAT_SEC` (int)
+- MQTT: `BASE_TOPIC`, `STATUS_TOPIC`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_QOS`, `MQTT_RETAIN`
+- Influx: `INFLUX_URL`, `INFLUX_ORG`, `INFLUX_TOKEN`, `INFLUX_BUCKET_RAW`
+
+Setup Steps
+1) Mosquitto
+- `sudo apt install -y mosquitto mosquitto-clients`
+- `/etc/mosquitto/conf.d/noesis.conf`:
+  listener 1883
+  allow_anonymous false
+  password_file /etc/mosquitto/passwd
+  persistence true
+  persistence_location /var/lib/mosquitto/
+  autosave_interval 30
+- `sudo mosquitto_passwd -c /etc/mosquitto/passwd noesis && sudo systemctl restart mosquitto`
+
+2) InfluxDB v2
+- Create buckets and a 1-minute rollup task (optional):
+  influx bucket create -n noesis_raw -r 90d || true
+  influx bucket create -n noesis_1m -r 730d || true
+  influx task create -n "noesis_occupancy_1m" -d '
+  option task = {name: "noesis_occupancy_1m", every: 1m}
+  from(bucket: "noesis_raw")
+    |> range(start: -task.every)
+    |> filter(fn: (r) => r._measurement == "occupancy")
+    |> aggregateWindow(every: 1m, fn: last, createEmpty: false)
+    |> to(bucket: "noesis_1m")
+  ' || true
+
+3) HomeSeer (mcsMQTT)
+- Broker: Mosquitto with `noesis` user/pass
+- Subscribe: `noesis/#`
+- Devices auto-create on first retained publish:
+  - occupied: status pairs 0=Vacant, 1=Occupied
+  - count: numeric
+- Exclude these from HS→Influx export to avoid duplicate points.
+
+Verification
+- MQTT: `mosquitto_sub -h 127.0.0.1 -t 'noesis/occupancy/#' -u noesis -P 'PASS' -v`
+- Influx: `influx query 'from(bucket:"noesis_raw") |> range(start:-15m) |> filter(fn:(r)=> r._measurement=="occupancy") |> last()'`
+
+Notes
+- Occupancy is emitted from the DeepStream analytics probe; ROI/zone names are sluggified to form `<room>`.
+- When a zone disappears, a "vacant" (count=0) event is published to ensure state transitions are captured.

--- a/docs/reference/Configuration_Map.md
+++ b/docs/reference/Configuration_Map.md
@@ -36,6 +36,15 @@ This document maps `config.py` sections and keys to their use in `deepstream_vid
 
 - `USE_NATIVE_DEEPSTREAM_TRACKER`: currently informational; pipeline always uses `nvtracker`
 
+## integrations (AppConfig.IntegrationsSettings)
+
+- `ENABLE_OCCUPANCY_PUBLISH`: toggles MQTT + Influx occupancy publishing
+- `HEARTBEAT_SEC`: heartbeat period for retained MQTT refresh (no Influx write)
+- MQTT: `BASE_TOPIC`, `STATUS_TOPIC`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_QOS`, `MQTT_RETAIN`
+  - Consumed to initialize `OccupancyPublisher` MQTT client and retained topics
+- Influx: `INFLUX_URL`, `INFLUX_ORG`, `INFLUX_TOKEN`, `INFLUX_BUCKET_RAW`
+  - Consumed to initialize `InfluxDBClient` and async write API
+
 ## output (AppConfig.OutputSettings)
 
 - `OUTPUT_DIR`, `SAVE_FRAMES`: respected at higher layers when saving frames; DeepStream provides JPEG bytes

--- a/docs/reference/Integrations_Playbook.md
+++ b/docs/reference/Integrations_Playbook.md
@@ -1,0 +1,143 @@
+# Integrations Playbook: InfluxDB + HomeSeer via MQTT
+
+This guide documents how the Noesis pipeline integrates with external systems, using our occupancy → MQTT + InfluxDB + HomeSeer setup as a concrete example. It also provides a repeatable pattern to add future integrations and new stats.
+
+## Scope
+
+- What we built: Occupancy state per ROI/zone published to MQTT (for automations) and InfluxDB (for history/analytics), consumed by HomeSeer via mcsMQTT.
+- Where it lives: Publisher in Python with config in `config.py`, wired into the DeepStream processor at runtime.
+- How to extend: Follow the same publisher pattern to add new topics/measurements or new sinks.
+
+## Architecture
+
+- Data source: DeepStream probe computes per-frame analytics (occupancy counts, transitions, tracks) inside `deepstream_video_pipeline.py`.
+- Publisher: `occupancy_publisher.py` handles MQTT retained topics and Influx write-on-change, with background heartbeats for retained MQTT refresh.
+- Wiring: `main.py` builds `OccupancyConfig` from `config.integrations`, constructs `OccupancyPublisher`, and attaches it to the processor. The probe calls `publish_state()` when counts change or vacate.
+- Isolation: Publishing errors never impact the real-time pipeline; all calls are wrapped in try/except and async where applicable.
+
+## Program Changes (Noesis)
+
+1) Configuration (new section)
+- Added `AppConfig.IntegrationsSettings` in `config.py:293` with keys:
+  - Enable + cadence: `ENABLE_OCCUPANCY_PUBLISH`, `HEARTBEAT_SEC`
+  - MQTT: `BASE_TOPIC`, `STATUS_TOPIC`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_QOS`, `MQTT_RETAIN`
+  - Influx: `INFLUX_URL`, `INFLUX_ORG`, `INFLUX_TOKEN`, `INFLUX_BUCKET_RAW`
+
+2) Publisher component
+- File: `occupancy_publisher.py:76`
+- Behavior:
+  - On change → publish retained MQTT scalars + JSON envelope, write an Influx point with nanosecond precision.
+  - On heartbeat → republish retained MQTT only (no Influx) to keep state visible to late subscribers.
+  - Slugifies ROI names to stable `<room>` ids for topics/tags.
+  - Deduplicates by `(occupied,count)` to avoid redundant writes.
+  - Gracefully tolerates missing libs (paho-mqtt/influxdb-client) and connection issues.
+
+3) Wiring into runtime
+- File: `main.py:418`
+- Builds `OccupancyConfig` from `config.integrations` and attaches the created `OccupancyPublisher` to the running DeepStream processor (`self.multi_stream_processor.occupancy_publisher = pub`).
+
+4) Emission site in pipeline
+- File: `deepstream_video_pipeline.py:993`
+- Each frame:
+  - Computes `occupancy = { zone: count }` from object/frame analytics.
+  - Calls `publish_state(room_id=zone, occupied=(count>0), count=count, ts_ns=...)` for seen zones.
+  - Emits explicit vacates (`occupied=false, count=0`) for zones previously seen but absent this frame.
+  - Never raises if publishing fails.
+
+## External Setup
+
+### MQTT Broker (Mosquitto)
+
+- Install: `sudo apt install -y mosquitto mosquitto-clients`
+- Configure `/etc/mosquitto/conf.d/noesis.conf`:
+  listener 1883
+  allow_anonymous false
+  password_file /etc/mosquitto/passwd
+  persistence true
+  persistence_location /var/lib/mosquitto/
+  autosave_interval 30
+- Create credentials and restart:
+  sudo mosquitto_passwd -c /etc/mosquitto/passwd noesis
+  sudo systemctl restart mosquitto
+- Verify retained messages:
+  mosquitto_sub -h <host> -u noesis -P '<pass>' -t 'noesis/occupancy/#' -v
+
+### InfluxDB v2
+
+- Buckets:
+  influx bucket create -n noesis_raw -r 90d
+  influx bucket create -n noesis_1m -r 730d
+- Optional 1-minute rollup task:
+  influx task create -n "noesis_occupancy_1m" -d '
+  option task = {name: "noesis_occupancy_1m", every: 1m}
+  from(bucket: "noesis_raw")
+    |> range(start: -task.every)
+    |> filter(fn: (r) => r._measurement == "occupancy")
+    |> aggregateWindow(every: 1m, fn: last, createEmpty: false)
+    |> to(bucket: "noesis_1m")
+  '
+- Configure token/org/url in `config.integrations`.
+- Verify recent point:
+  influx query 'from(bucket:"noesis_raw") |> range(start:-15m) |> filter(fn:(r)=> r._measurement=="occupancy") |> last()'
+
+### HomeSeer (mcsMQTT)
+
+- Broker connection: point to Mosquitto with `noesis` user/pass.
+- Subscribe: `noesis/#`.
+- Device auto-creation: first retained publishes create devices for each room:
+  - `<room>/occupied` (discrete 0/1 → Vacant/Occupied)
+  - `<room>/count` (numeric)
+- Recommended: exclude these devices from HS→Influx export to avoid duplicate points when Noesis writes directly to Influx.
+- Automations: trigger on changes to `<room>/occupied` or thresholds on `<room>/count`.
+
+## Operational Checklists
+
+- Service health: Noesis logs indicate MQTT/Influx availability at startup; `noesis/status` retained topic shows online/offline via LWT.
+- End-to-end:
+  - Move in a monitored ROI → watch MQTT topics update and a new Influx point appear.
+  - Clear ROI → observe a vacate event (count=0) and device update in HomeSeer.
+
+## Pattern: Adding a New Integration or Stat
+
+1) Define the schema
+- MQTT topics: prefer `base/<entity>/<metric>` for scalars and `base/<entity>` for JSON envelopes.
+- Influx: measurement name, tags (identify entity), fields (numeric/boolean), and write precision.
+- Retention and rollups: pick buckets and optional tasks.
+
+2) Implement a Publisher (if needed)
+- Start with `occupancy_publisher.py` as a template:
+  - Connection setup, LWT, retries, dedupe, heartbeat, graceful shutdown.
+  - Keep publishing async/non-blocking where possible.
+
+3) Wire it into runtime
+- Build a `Config` dataclass under `AppConfig.integrations` with required knobs.
+- Initialize publisher in `main.py` and attach to the processor or relevant component.
+
+4) Emit data from the right place
+- Frame/analytics-derived stats: `deepstream_video_pipeline.py` (inside the probe that already computes analytics).
+- System/process stats: `main.py` (e.g., uptime, app metrics) or a dedicated metrics loop.
+- Web telemetry: follow `docs/reference/Telemetry_Schema.md` if you surface data to the front-end.
+
+5) Verify and observe
+- CLI tools: `mosquitto_sub`, `influx query`.
+- Logs: check for connection errors or missing libraries.
+
+## Pattern: Adding More Occupancy/Analytics Fields
+
+- New MQTT fields: add scalars and include in the JSON envelope. Prefer simple numeric/boolean payloads for device mapping in HomeSeer.
+- New Influx fields: add fields to the point with careful consideration of cardinality (keep tags low-cardinality, fields for values).
+- Example extension: add `enter_events` and `exit_events` per zone as counters; publish to `noesis/occupancy/<room>/enters` and `.../exits`, and write to Influx under the same measurement.
+
+## Security & Ops Considerations
+
+- Secrets: inject broker passwords and Influx tokens via environment or protected config; avoid committing real tokens.
+- QoS/retain: QoS 1 and retained topics are used to guarantee state availability for late subscribers.
+- Failure isolation: all publishing is best-effort and never blocks the video pipeline.
+
+## References
+
+- Occupancy publisher: `occupancy_publisher.py:76`
+- Wiring: `main.py:418`
+- Emission site: `deepstream_video_pipeline.py:993`
+- Topic and schema summary: `docs/reference/Occupancy_Publishing.md`
+- Setup walkthrough: `docs/integrations/occupancy_mqtt_influx.md`

--- a/docs/reference/Occupancy_Publishing.md
+++ b/docs/reference/Occupancy_Publishing.md
@@ -1,0 +1,79 @@
+# Occupancy Publishing (MQTT + InfluxDB + HomeSeer)
+
+This document describes how Noesis publishes room/zone occupancy to MQTT and InfluxDB, and how it connects to HomeSeer automations.
+
+## Overview
+
+- Publishes retained MQTT topics per room/zone for automation.
+- Writes occupancy state changes to InfluxDB for history/analytics.
+- Heartbeat periodically refreshes retained MQTT topics without writing to Influx.
+
+Dependencies
+- Python: `paho-mqtt`, `influxdb-client` (see `requirements.txt`)
+
+## Data Flow
+
+- DeepStream probe computes per-frame occupancy per ROI/zone and detects vacates.
+- On each frame, deltas are sent to a shared `OccupancyPublisher`:
+  - Initialization and wiring: `main.py` attaches the publisher to the running DeepStream processor.
+  - Emission: `deepstream_video_pipeline.py` publishes counts and explicit vacates.
+
+## MQTT Topics
+
+- Base: `noesis/occupancy/<room>` where `<room>` is a stable slug of the ROI/zone name.
+- Scalars (retained, QoS 1):
+  - `noesis/occupancy/<room>/occupied` → "0" or "1"
+  - `noesis/occupancy/<room>/count` → "0..N"
+- Envelope (retained, QoS 1):
+  - `noesis/occupancy/<room>` → JSON `{ ts: ISO8601, occupied: bool, count: int }`
+- Status: `noesis/status` → "online"/"offline" (retained) via MQTT LWT.
+
+Notes
+- Retained messages ensure HomeSeer and other subscribers see the latest state on connect.
+- Heartbeat republishes retained MQTT values on an interval; no Influx writes on heartbeat.
+
+## InfluxDB Series
+
+- Measurement: `occupancy`
+- Tags: `room_id=<room>`
+- Fields: `occupied` (int 0/1), `count` (int)
+- Precision: nanoseconds
+- Bucket: `integrations.INFLUX_BUCKET_RAW` (default `noesis_raw`)
+- Writes occur only on changes to reduce volume.
+
+## Configuration (config.py → AppConfig.integrations)
+
+- Enable: `ENABLE_OCCUPANCY_PUBLISH` (bool)
+- Heartbeat: `HEARTBEAT_SEC` (int)
+- MQTT: `BASE_TOPIC`, `STATUS_TOPIC`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_QOS`, `MQTT_RETAIN`
+- Influx: `INFLUX_URL`, `INFLUX_ORG`, `INFLUX_TOKEN`, `INFLUX_BUCKET_RAW`
+
+## HomeSeer (mcsMQTT) Notes
+
+- Point mcsMQTT at your broker and subscribe `noesis/#`.
+- Devices auto-create on first retained publishes:
+  - `<room>/occupied` → discrete status (0=Vacant, 1=Occupied)
+  - `<room>/count` → numeric
+- Exclude these topics from HS→Influx export to avoid duplicate points if HS is also writing to Influx.
+
+## Code References
+
+- Publisher implementation: `occupancy_publisher.py:76`
+- Wiring in application: `main.py:418`
+- DeepStream emission site (per-frame deltas + vacates): `deepstream_video_pipeline.py:993`
+
+## Verification
+
+- MQTT: `mosquitto_sub -h <host> -t 'noesis/occupancy/#' -u <user> -P <pass> -v`
+- Influx (example):
+  - `from(bucket:"noesis_raw") |> range(start:-15m) |> filter(fn:(r)=> r._measurement=="occupancy") |> last()`
+
+## Troubleshooting
+
+- No MQTT publishes: verify broker host/port and credentials in `integrations` config, and that `paho-mqtt` is installed.
+- No Influx writes: confirm `INFLUX_URL/ORG/TOKEN/BCKET` and that `influxdb-client` is installed; remember writes only occur on state changes.
+- Missing vacate events: ensure ROI names are stable; publisher slugs names to form the `<room>` key.
+
+## See Also
+
+- Setup walkthrough and examples: `docs/integrations/occupancy_mqtt_influx.md`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -25,6 +25,9 @@ Purpose: Mapping from `config.py` to pipeline components and runtime controls.
 ### `Occupancy_Publishing.md`
 Purpose: Reference for the MQTT + InfluxDB occupancy publisher and HomeSeer integration.
 
+### `Integrations_Playbook.md`
+Purpose: Step-by-step integration guide for InfluxDB + HomeSeer and a reusable pattern to add future integrations and stats.
+
 ### `Dynamic_Sensors.md`
 Purpose: How to add/remove sources at runtime using `nvmultiurisrcbin` REST API.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -22,6 +22,9 @@ Purpose: Inventory of DeepStream elements, properties, probes, and dynamic branc
 ### `Configuration_Map.md`
 Purpose: Mapping from `config.py` to pipeline components and runtime controls.
 
+### `Occupancy_Publishing.md`
+Purpose: Reference for the MQTT + InfluxDB occupancy publisher and HomeSeer integration.
+
 ### `Dynamic_Sensors.md`
 Purpose: How to add/remove sources at runtime using `nvmultiurisrcbin` REST API.
 

--- a/libproxy_fake.c
+++ b/libproxy_fake.c
@@ -1,5 +1,0 @@
-const char* px_proxy_factory_get_proxies(void* factory, const char* url) {
-    (void)factory;
-    (void)url;
-    return "direct://";
-}

--- a/main.py
+++ b/main.py
@@ -138,6 +138,8 @@ class ApplicationManager:
         # Register signal handlers
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
+        # Integrations
+        self._occupancy_publisher = None
     
     def _signal_handler(self, sig, frame):
         """Handle termination signals with graceful shutdown
@@ -404,6 +406,48 @@ class ApplicationManager:
             # Store single processor (not per-camera)
             self.multi_stream_processor = processor
             self.logger.info(f"✅ Multi-stream DeepStream processor started successfully with {len(enabled_sources)} streams")
+
+            # Wire OccupancyPublisher if enabled
+            try:
+                if getattr(self.config.integrations, 'ENABLE_OCCUPANCY_PUBLISH', False):
+                    self.logger.info("🔌 Initializing OccupancyPublisher (MQTT + Influx)")
+                    try:
+                        print(f"🔌 OccupancyPublisher enabled: MQTT {self.config.integrations.MQTT_HOST}:{self.config.integrations.MQTT_PORT} base={self.config.integrations.BASE_TOPIC} | Influx bucket={self.config.integrations.INFLUX_BUCKET_RAW}")
+                    except Exception:
+                        pass
+                    from occupancy_publisher import OccupancyPublisher, OccupancyConfig
+                    occ_cfg = OccupancyConfig(
+                        enabled=True,
+                        heartbeat_sec=int(self.config.integrations.HEARTBEAT_SEC),
+                        base_topic=str(self.config.integrations.BASE_TOPIC),
+                        status_topic=str(self.config.integrations.STATUS_TOPIC),
+                        mqtt_host=str(self.config.integrations.MQTT_HOST),
+                        mqtt_port=int(self.config.integrations.MQTT_PORT),
+                        mqtt_username=str(self.config.integrations.MQTT_USERNAME),
+                        mqtt_password=str(self.config.integrations.MQTT_PASSWORD),
+                        mqtt_qos=int(self.config.integrations.MQTT_QOS),
+                        mqtt_retain=bool(self.config.integrations.MQTT_RETAIN),
+                        influx_url=str(self.config.integrations.INFLUX_URL),
+                        influx_org=str(self.config.integrations.INFLUX_ORG),
+                        influx_token=str(self.config.integrations.INFLUX_TOKEN),
+                        influx_bucket_raw=str(self.config.integrations.INFLUX_BUCKET_RAW),
+                    )
+                    pub = OccupancyPublisher(occ_cfg, logger=logging.getLogger("OccupancyPublisher"))
+                    self._occupancy_publisher = pub
+                    # attach to processor so DS code can emit from probe
+                    try:
+                        setattr(self.multi_stream_processor, 'occupancy_publisher', pub)
+                        self.logger.info("✅ Attached OccupancyPublisher to DeepStream processor")
+                        try:
+                            print("✅ OccupancyPublisher attached to DeepStream processor")
+                        except Exception:
+                            pass
+                    except Exception as e:
+                        self.logger.warning(f"Unable to attach OccupancyPublisher to processor: {e}")
+                else:
+                    self.logger.info("Occupancy publishing disabled via config")
+            except Exception as e:
+                self.logger.error(f"Error initializing OccupancyPublisher: {e}")
             
             # Give processor a moment to initialize
             time.sleep(1.0)
@@ -1040,6 +1084,16 @@ class ApplicationManager:
                 self.logger.info("Stopped multi-stream processor")
             except Exception as e:
                 self.logger.error(f"Error stopping multi-stream processor: {e}")
+
+        # Stop integrations (OccupancyPublisher)
+        if getattr(self, '_occupancy_publisher', None) is not None:
+            try:
+                self.logger.info("Stopping OccupancyPublisher")
+                self._occupancy_publisher.close()
+                self._occupancy_publisher = None
+                self.logger.info("Stopped OccupancyPublisher")
+            except Exception as e:
+                self.logger.error(f"Error stopping OccupancyPublisher: {e}")
         
         # STEP 4: Stop result processing thread
         if hasattr(self, 'result_thread') and self.result_thread:

--- a/oai2-fe/src/hooks/useWebSocketClient.ts
+++ b/oai2-fe/src/hooks/useWebSocketClient.ts
@@ -29,21 +29,72 @@ export function useWebSocketClient(url: string, handlers: FrameHandlers) {
   const [status, setStatus] = useState<'connecting' | 'open' | 'closed' | 'error'>('connecting');
   const [retry, setRetry] = useState(0);
   const maxRetries = 10;
+  const heartbeatRef = useRef<NodeJS.Timeout | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     let stop = false;
+
+    const startHeartbeat = (ws: WebSocket) => {
+      // Clear any existing heartbeat
+      if (heartbeatRef.current) {
+        clearInterval(heartbeatRef.current);
+      }
+
+      // Send a heartbeat every 30 seconds to keep connection alive
+      heartbeatRef.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            // Send a simple ping message that the server will echo back
+            ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
+          } catch (e) {
+            console.warn('Failed to send heartbeat:', e);
+          }
+        }
+      }, 30000); // 30 seconds
+    };
+
+    const stopHeartbeat = () => {
+      if (heartbeatRef.current) {
+        clearInterval(heartbeatRef.current);
+        heartbeatRef.current = null;
+      }
+    };
+
     const connect = () => {
       setStatus('connecting');
+
+      // Clear any existing reconnect timeout
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+
       const ws = new WebSocket(url);
       socketRef.current = ws;
-      ws.onopen = () => setStatus('open');
-      ws.onclose = () => {
+
+      ws.onopen = () => {
+        setStatus('open');
+        startHeartbeat(ws);
+        console.log('WebSocket connected, heartbeat started');
+      };
+
+      ws.onclose = (event) => {
         setStatus('closed');
+        stopHeartbeat();
+        console.log(`WebSocket closed: code=${event.code}, reason=${event.reason}`);
+
         if (!stop && retry < maxRetries) {
-          setTimeout(() => setRetry(r => r + 1), 5000);
+          const delay = Math.min(5000 * Math.pow(2, retry), 30000); // Exponential backoff, max 30s
+          console.log(`Attempting reconnection ${retry + 1}/${maxRetries} in ${delay}ms`);
+          reconnectTimeoutRef.current = setTimeout(() => setRetry(r => r + 1), delay);
         }
       };
-      ws.onerror = () => setStatus('error');
+
+      ws.onerror = (error) => {
+        setStatus('error');
+        console.error('WebSocket error:', error);
+      };
       ws.onmessage = async (ev: MessageEvent) => {
         try {
           if (ev.data instanceof Blob) {
@@ -75,6 +126,25 @@ export function useWebSocketClient(url: string, handlers: FrameHandlers) {
             return;
           }
           const data = JSON.parse(ev.data);
+
+          // Handle ping messages by responding with pong
+          if (data.type === 'ping') {
+            try {
+              ws.send(JSON.stringify({ type: 'pong', timestamp: data.timestamp }));
+              console.debug('Sent pong response to server ping');
+            } catch (e) {
+              console.warn('Failed to send pong response:', e);
+            }
+            return;
+          }
+
+          // Handle pong responses from server
+          if (data.type === 'pong') {
+            const latency = Date.now() - (data.timestamp || 0);
+            console.debug(`Received pong from server (latency: ${latency}ms)`);
+            return;
+          }
+
           if (data.type === 'stats' && data.payload) {
             handlers.onStats(data.payload as StatsPayload);
           } else if (data.type === 'toggle_update' && data.toggle_name === 'trail_visualization_enabled') {
@@ -88,7 +158,15 @@ export function useWebSocketClient(url: string, handlers: FrameHandlers) {
       };
     };
     connect();
-    return () => { stop = true; socketRef.current?.close(); };
+    return () => {
+      stop = true;
+      stopHeartbeat();
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      socketRef.current?.close();
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url, retry]);
 

--- a/occupancy_publisher.py
+++ b/occupancy_publisher.py
@@ -1,0 +1,245 @@
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Optional, Tuple
+
+try:
+    import paho.mqtt.client as mqtt
+except Exception as e:  # pragma: no cover
+    mqtt = None  # type: ignore
+
+try:
+    from influxdb_client import InfluxDBClient, Point, WritePrecision
+    from influxdb_client.client.write_api import ASYNCHRONOUS
+except Exception as e:  # pragma: no cover
+    InfluxDBClient = None  # type: ignore
+    Point = None  # type: ignore
+    WritePrecision = None  # type: ignore
+    ASYNCHRONOUS = None  # type: ignore
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_from_ns(ts_ns: Optional[int]) -> str:
+    if not ts_ns:
+        return _iso_now()
+    return datetime.fromtimestamp(ts_ns / 1e9, tz=timezone.utc).isoformat()
+
+
+def _slugify_room(room_id: str) -> str:
+    # Minimal, stable slug for MQTT topics
+    s = str(room_id).strip().lower()
+    out = []
+    for ch in s:
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in [' ', '_', '-', '/']:
+            out.append('-')
+        else:
+            # drop other punctuation
+            out.append('-')
+    # collapse multiple '-'
+    slug = []
+    prev_dash = False
+    for ch in out:
+        if ch == '-' and prev_dash:
+            continue
+        prev_dash = ch == '-'
+        slug.append(ch)
+    slug_s = ''.join(slug).strip('-')
+    return slug_s or 'unknown'
+
+
+@dataclass
+class OccupancyConfig:
+    enabled: bool
+    heartbeat_sec: int
+    base_topic: str
+    status_topic: str
+    mqtt_host: str
+    mqtt_port: int
+    mqtt_username: str
+    mqtt_password: str
+    mqtt_qos: int
+    mqtt_retain: bool
+    influx_url: str
+    influx_org: str
+    influx_token: str
+    influx_bucket_raw: str
+
+
+class OccupancyPublisher:
+    """Publishes occupancy state changes to MQTT and InfluxDB.
+
+    - MQTT publishes retained scalar topics and a JSON envelope per room.
+    - InfluxDB writes occur only on state changes (not on heartbeats).
+    - A background heartbeat refreshes retained MQTT topics.
+    """
+
+    def __init__(self, cfg: OccupancyConfig, logger: Optional[logging.Logger] = None) -> None:
+        self.cfg = cfg
+        self.logger = logger or logging.getLogger("OccupancyPublisher")
+        self._last: Dict[str, Tuple[int, int]] = {}
+        self._hb_stop = threading.Event()
+
+        self.client: Optional["mqtt.Client"] = None
+        self.ic: Optional["InfluxDBClient"] = None
+        self.write_api = None
+
+        # Initialize MQTT
+        if mqtt is None:
+            self.logger.error("paho-mqtt is not installed; MQTT publishing disabled")
+        else:
+            try:
+                self.client = mqtt.Client(client_id="noesis-occupancy-pub", clean_session=True)
+                if self.cfg.mqtt_username:
+                    self.client.username_pw_set(self.cfg.mqtt_username, self.cfg.mqtt_password)
+                # LWT
+                self.client.will_set(
+                    self.cfg.status_topic, payload="offline", qos=self.cfg.mqtt_qos, retain=True
+                )
+                self.client.on_connect = self._on_connect
+                self.client.on_disconnect = self._on_disconnect
+                self.client.connect_async(self.cfg.mqtt_host, self.cfg.mqtt_port, 60)
+                self.client.loop_start()
+            except Exception as e:
+                self.logger.error(f"Failed to init/connect MQTT client: {e}")
+                self.client = None
+
+        # Initialize InfluxDB client (optional)
+        if InfluxDBClient is None:
+            self.logger.error("influxdb-client is not installed; Influx writes disabled")
+        else:
+            try:
+                self.ic = InfluxDBClient(url=self.cfg.influx_url, token=self.cfg.influx_token, org=self.cfg.influx_org)
+                # Use async write to keep the DS thread snappy
+                self.write_api = self.ic.write_api(write_options=ASYNCHRONOUS)
+            except Exception as e:
+                self.logger.error(f"Failed to init InfluxDB client: {e}")
+                self.ic = None
+                self.write_api = None
+
+        # Start heartbeat thread
+        self._hb_thread = threading.Thread(target=self._heartbeat_loop, name="OccupancyHeartbeat", daemon=True)
+        self._hb_thread.start()
+
+        self.logger.info(
+            f"OccupancyPublisher ready (MQTT={'on' if self.client else 'off'}, Influx={'on' if self.write_api else 'off'})"
+        )
+
+    # MQTT callbacks
+    def _on_connect(self, client, userdata, flags, rc):  # pragma: no cover
+        try:
+            if rc == 0:
+                client.publish(self.cfg.status_topic, payload="online", qos=self.cfg.mqtt_qos, retain=True)
+                self.logger.info("MQTT connected; status=online published")
+            else:
+                self.logger.error(f"MQTT connection failed with rc={rc}")
+        except Exception:
+            pass
+
+    def _on_disconnect(self, client, userdata, rc):  # pragma: no cover
+        # loop_start handles reconnects; nothing else needed
+        if rc != 0:
+            self.logger.warning(f"MQTT disconnected unexpectedly (rc={rc})")
+
+    def close(self):
+        try:
+            self._hb_stop.set()
+            if self._hb_thread.is_alive():
+                self._hb_thread.join(timeout=2.0)
+        except Exception:
+            pass
+        try:
+            if self.client is not None:
+                try:
+                    self.client.publish(self.cfg.status_topic, payload="offline", qos=self.cfg.mqtt_qos, retain=True)
+                except Exception:
+                    pass
+                self.client.loop_stop()
+                self.client.disconnect()
+        except Exception:
+            pass
+        try:
+            if self.ic is not None:
+                self.ic.close()
+        except Exception:
+            pass
+
+    def publish_state(self, room_id: str, occupied: bool, count: int, ts_ns: Optional[int] = None):
+        """Publish one room state. Writes to Influx only on change. Always retained MQTT publish on change.
+
+        This is safe to call on each frame; dedupe avoids redundant work.
+        """
+        try:
+            slug = _slugify_room(room_id)
+            occ_i = 1 if bool(occupied) else 0
+            cnt = int(count)
+            last = self._last.get(slug)
+            is_change = (last is None) or (last != (occ_i, cnt))
+            ts_ns_use = ts_ns or int(time.time_ns())
+            ts_iso = _iso_from_ns(ts_ns_use)
+
+            if is_change:
+                # MQTT retained scalars + JSON
+                base = f"{self.cfg.base_topic}/{slug}"
+                self._mqtt_publish(f"{base}/occupied", str(occ_i))
+                self._mqtt_publish(f"{base}/count", str(cnt))
+                env = {"ts": ts_iso, "occupied": bool(occ_i), "count": cnt}
+                self._mqtt_publish(base, json.dumps(env))
+
+                # InfluxDB write on change
+                if self.write_api and Point is not None and WritePrecision is not None:
+                    try:
+                        p = (
+                            Point("occupancy")
+                            .tag("room_id", slug)
+                            .field("occupied", occ_i)
+                            .field("count", cnt)
+                            .time(ts_ns_use, WritePrecision.NS)
+                        )
+                        self.write_api.write(bucket=self.cfg.influx_bucket_raw, org=self.cfg.influx_org, record=p)
+                    except Exception as e:
+                        self.logger.error(f"Influx write error for room {slug}: {e}")
+
+                self._last[slug] = (occ_i, cnt)
+        except Exception as e:
+            self.logger.error(f"publish_state error for room={room_id}: {e}")
+
+    def _mqtt_publish(self, topic: str, payload: str, tries: int = 3):
+        if not self.client:
+            return
+        delay = 0.5
+        for attempt in range(tries):
+            try:
+                # fire-and-forget; paho handles queueing
+                self.client.publish(topic, payload=payload, qos=self.cfg.mqtt_qos, retain=self.cfg.mqtt_retain)
+                return
+            except Exception as e:
+                if attempt == tries - 1:
+                    self.logger.error(f"MQTT publish failed for {topic}: {e}")
+                time.sleep(delay)
+                delay *= 2
+
+    def _heartbeat_loop(self):
+        # Periodically refresh retained MQTT state for all known rooms
+        interval = max(5, int(self.cfg.heartbeat_sec or 60))
+        while not self._hb_stop.is_set():
+            try:
+                if self.client and self._last:
+                    for room, (occ_i, cnt) in list(self._last.items()):
+                        base = f"{self.cfg.base_topic}/{room}"
+                        env = {"ts": _iso_now(), "occupied": bool(occ_i), "count": int(cnt), "event": "heartbeat"}
+                        self._mqtt_publish(f"{base}/occupied", str(occ_i))
+                        self._mqtt_publish(f"{base}/count", str(cnt))
+                        self._mqtt_publish(base, json.dumps(env))
+                # No Influx write on heartbeat
+            except Exception:
+                pass
+            self._hb_stop.wait(interval)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,10 @@ requests==2.32.4
 pyyaml==6.0.2
 psutil==7.0.0
 
+# Messaging & storage integrations
+paho-mqtt==2.1.0
+influxdb-client==1.48.0
+
 # --- Added packages that are installed but not in requirements.txt ---
 # Deep learning optimization
 tensorrt==10.12.0.36

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -47,17 +47,35 @@ class WebSocketServer:
     async def _cleanup_stale_connections(self):
         """Periodically clean up any stale or closed connections"""
         try:
+            # Since the broadcast method already handles cleanup when connections fail,
+            # we'll make this cleanup much simpler and safer
             stale_clients = set()
+
             for client in self.connected_clients:
-                # Check if client connection is closed
-                if client.closed:
+                try:
+                    # Check various attributes that might indicate a closed connection
+                    is_closed = False
+
+                    # Try the most common attributes first
+                    if hasattr(client, 'closed') and getattr(client, 'closed', False):
+                        is_closed = True
+                    elif hasattr(client, 'close_code') and getattr(client, 'close_code', None) is not None:
+                        is_closed = True
+                    elif hasattr(client, 'state') and getattr(client, 'state', None) == 'CLOSED':
+                        is_closed = True
+
+                    if is_closed:
+                        stale_clients.add(client)
+
+                except Exception:
+                    # If we can't safely inspect the client, assume it's stale
                     stale_clients.add(client)
 
             if stale_clients:
                 for client in stale_clients:
                     if client in self.connected_clients:
                         self.connected_clients.remove(client)
-                        client_ip = client.remote_address if hasattr(client, 'remote_address') else "Unknown"
+                        client_ip = getattr(client, 'remote_address', 'Unknown') if hasattr(client, 'remote_address') else "Unknown"
                         self.logger.info(f"Cleaned up stale connection for client {client_ip}")
                 self.logger.debug(f"Cleaned up {len(stale_clients)} stale connections")
 
@@ -71,9 +89,9 @@ class WebSocketServer:
 
         while self.running:
             try:
-                # Periodic cleanup of stale connections (every 30 seconds)
+                # Periodic cleanup of stale connections (every 60 seconds, reduced frequency)
                 cleanup_counter += 1
-                if cleanup_counter >= 30:
+                if cleanup_counter >= 60:
                     await self._cleanup_stale_connections()
                     cleanup_counter = 0
 
@@ -129,14 +147,15 @@ class WebSocketServer:
                 self.event_loop = None
 
             # Create server with backpressure and heartbeat settings
+            # Increased ping interval and timeout for better stability
             self.server = await websockets.serve(
                 self.handle_client,
                 self.host,
                 self.port,
                 max_size=None,       # allow large binary frames
                 max_queue=1,         # minimize buffering to reduce latency
-                ping_interval=20,    # keep-alive pings
-                ping_timeout=20      # disconnect stale clients
+                ping_interval=60,    # keep-alive pings every 60 seconds (was 20)
+                ping_timeout=30      # wait 30 seconds for pong response (was 20)
             )
 
             # Start periodic stats broadcast task if callback is provided
@@ -150,6 +169,7 @@ class WebSocketServer:
             print(f"🚀 WebSocket server is LIVE on {self.host}:{self.port}")
             print(f"📡 Server listening for connections on ws://{self.host}:{self.port}")
             print(f"🔄 Periodic stats broadcast: {'ENABLED' if self.stats_callback else 'DISABLED'}")
+            print(f"💓 Keep-alive: ping every 60s, timeout 30s")
             self.logger.info("WebSocket server startup completed successfully")
 
         except OSError as e:
@@ -289,6 +309,20 @@ class WebSocketServer:
                         else:
                             self.logger.warning(f"Invalid set_vis_toggle message from {client_ip}: {data}")
 
+                    # Handle client heartbeat ping messages
+                    elif data.get('type') == 'ping':
+                        timestamp = data.get('timestamp')
+                        self.logger.debug(f"Received ping from {client_ip} (timestamp: {timestamp})")
+                        # Send pong response
+                        try:
+                            pong_message = {
+                                'type': 'pong',
+                                'timestamp': timestamp
+                            }
+                            await websocket.send(json.dumps(pong_message))
+                        except Exception as e:
+                            self.logger.warning(f"Failed to send pong response to {client_ip}: {e}")
+
                     # Handle detection configuration updates
                     elif data.get('type') == 'update_detection_config':
                         config_data = data.get('config', {})
@@ -343,11 +377,15 @@ class WebSocketServer:
                     self.logger.error(f"Error processing message from {client_ip}: {e}")
 
         except websockets.exceptions.ConnectionClosedOK:
-            self.logger.info(f"Client {client_ip} disconnected normally.")
+            self.logger.info(f"Client {client_ip} disconnected normally (code: 1000).")
             print(f"❌ Client {client_ip} disconnected normally.")
         except websockets.exceptions.ConnectionClosedError as e:
-            self.logger.warning(f"Client {client_ip} disconnected with error: {e}")
-            print(f"❌ Client {client_ip} disconnected with error: {e}")
+            # Log ping timeout errors as info instead of warning to reduce noise
+            if "keepalive ping timeout" in str(e).lower():
+                self.logger.info(f"Client {client_ip} disconnected due to ping timeout - connection cleaned up.")
+            else:
+                self.logger.warning(f"Client {client_ip} disconnected with error: {e}")
+                print(f"❌ Client {client_ip} disconnected with error: {e}")
         except Exception as e:
             self.logger.error(f"Unexpected error with client {client_ip}: {e}")
         finally:
@@ -370,6 +408,7 @@ class WebSocketServer:
 
         message_str = ""
         disconnected_clients = set()
+        active_clients = set(self.connected_clients)  # Create a copy to iterate over
 
         try:
             # Prepare message based on type
@@ -378,19 +417,23 @@ class WebSocketServer:
                 message = convert_numpy_types(message)
                 message_str = json.dumps(message)
             elif isinstance(message, bytes):
-                # Binary message
+                # Binary message - send to active clients only
                 results = await asyncio.gather(
-                    *[client.send(message) for client in self.connected_clients],
+                    *[client.send(message) for client in active_clients],
                     return_exceptions=True
                 )
                 # Check for errors and mark disconnected clients
                 for i, result in enumerate(results):
                     if isinstance(result, Exception):
-                        client = list(self.connected_clients)[i] if i < len(self.connected_clients) else None
+                        client = list(active_clients)[i] if i < len(active_clients) else None
                         if client:
                             disconnected_clients.add(client)
                         client_ip = client.remote_address if client and hasattr(client, 'remote_address') else "Unknown"
-                        self.logger.error(f"Failed to send binary message to {client_ip}: {result}")
+                        # Only log ping timeout errors to reduce noise, but still handle all exceptions
+                        if "keepalive ping timeout" in str(result):
+                            self.logger.debug(f"Client {client_ip} ping timeout - will be cleaned up")
+                        else:
+                            self.logger.error(f"Failed to send binary message to {client_ip}: {result}")
                 return
             elif isinstance(message, str):
                 # String message
@@ -399,32 +442,36 @@ class WebSocketServer:
                 self.logger.warning(f"Unknown message type: {type(message)}")
                 return
 
-            # Send string message to all clients
+            # Send string message to active clients only
             results = await asyncio.gather(
-                *[client.send(message_str) for client in self.connected_clients],
+                *[client.send(message_str) for client in active_clients],
                 return_exceptions=True
             )
 
             # Check for errors and mark disconnected clients
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
-                    client = list(self.connected_clients)[i] if i < len(self.connected_clients) else None
+                    client = list(active_clients)[i] if i < len(active_clients) else None
                     if client:
                         disconnected_clients.add(client)
                     client_ip = client.remote_address if client and hasattr(client, 'remote_address') else "Unknown"
-                    self.logger.error(f"Failed to send message to {client_ip}: {result}")
+                    # Only log ping timeout errors as debug to reduce noise
+                    if "keepalive ping timeout" in str(result):
+                        self.logger.debug(f"Client {client_ip} ping timeout - will be cleaned up")
+                    else:
+                        self.logger.error(f"Failed to send message to {client_ip}: {result}")
 
         except Exception as e:
             self.logger.error(f"Broadcast error: {e}")
         finally:
-            # Clean up disconnected clients from the set
+            # Immediately clean up disconnected clients from the set
             if disconnected_clients:
                 for client in disconnected_clients:
                     if client in self.connected_clients:
                         self.connected_clients.remove(client)
                         client_ip = client.remote_address if hasattr(client, 'remote_address') else "Unknown"
                         self.logger.info(f"Removed disconnected client {client_ip} from connected clients")
-                self.logger.debug(f"Cleaned up {len(disconnected_clients)} disconnected clients")
+                self.logger.debug(f"Cleaned up {len(disconnected_clients)} disconnected clients during broadcast")
     
     def broadcast_sync(self, message):
         """Synchronous version of broadcast for use from other threads


### PR DESCRIPTION
**Description**

- Adds OccupancyPublisher to publish retained MQTT topics per room and write change-only points to InfluxDB.
- Wires publisher in main.py; DeepStream probe emits deltas and explicit vacates.
- MQTT topics: noesis/occupancy/<room>/{occupied,count} and JSON envelope at noesis/occupancy/<room>; status LWT at noesis/status.
- Influx: measurement occupancy with room_id tag, occupied and count fields (ns precision).
- Configurable via AppConfig.integrations (MQTT, Influx, heartbeat, enable flag).
- Non-blocking, retry-tolerant; heartbeat refreshes MQTT only.

**Docs**

- Added docs/reference/Occupancy_Publishing.md
- Added docs/reference/Integrations_Playbook.md
- Updated docs/reference/Configuration_Map.md and docs/integrations/occupancy_mqtt_influx.md