### PR TITLE
Adjust room extents on dashboard

### DIFF
--- a/oai2-fe/src/App.tsx
+++ b/oai2-fe/src/App.tsx
@@ -359,6 +359,20 @@ function Dashboard() {
     onMADepth: handleMADepth,
     onFloorplan: handleFloorplan
   });
+
+  // Periodically request MapAnything floorplan bounds for each camera; fail-fast usage in MapPanel
+  useEffect(() => {
+    if (status !== 'open') return;
+    const cams: CameraKey[] = ['living-room', 'kitchen', 'family-room'];
+    const requestAll = () => {
+      cams.forEach((cam) => {
+        requestFloorplan({ camera: cam, maxAgeSec: 60, gridResM: 0.5, maxExtentM: 20 });
+      });
+    };
+    requestAll();
+    const id = window.setInterval(requestAll, 30000);
+    return () => window.clearInterval(id);
+  }, [status, requestFloorplan]);
   
   // Live EST/EDT clock for top bar
   const [estTime, setEstTime] = useState<string>("");
@@ -524,7 +538,16 @@ function Dashboard() {
 
           { /* Transitions panel removed */ }
 
-          <MapPanel store={trailStoreRef.current} visible={trailEnabled} />
+          <MapPanel
+            store={trailStoreRef.current}
+            visible={trailEnabled}
+            floorplans={floorplanData}
+            worldUsage={useMemo(() => ({
+              'living-room': usingWorldLivingRef.current,
+              'kitchen': usingWorldKitchenRef.current,
+              'family-room': usingWorldFamilyRef.current,
+            }), [tracksByCamKey, floorplanData])}
+          />
         </section>
       </main>
       <footer className="footer">

--- a/oai2-fe/src/components/MapPanel.tsx
+++ b/oai2-fe/src/components/MapPanel.tsx
@@ -1,43 +1,101 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { CameraKey, cameraLabel, colorForTrack } from '../lib/camera';
 import { TrailStore, drawTrails } from '../lib/trails';
+
+type Bounds = { min_x?: number; max_x?: number; min_z?: number; max_z?: number };
+type FloorplanResponse = {
+  camera_id?: string;
+  bounds?: Bounds;
+};
 
 export const MapPanel: React.FC<{
   store: TrailStore;
   visible: boolean;
-}> = ({ store, visible }) => {
+  floorplans?: Record<string, FloorplanResponse>;
+  worldUsage?: Record<CameraKey, boolean>;
+}> = ({ store, visible, floorplans = {}, worldUsage = { 'living-room': false, 'kitchen': false, 'family-room': false } }) => {
   const canvLiving = useRef<HTMLCanvasElement>(null);
   const canvKitchen = useRef<HTMLCanvasElement>(null);
   const canvFamily = useRef<HTMLCanvasElement>(null);
+
+  // Resolve bounds per camera key from floorplans map; enforce no-fallback (undefined -> do not render)
+  const boundsByKey = useMemo<Record<CameraKey, Bounds | undefined>>(() => {
+    const get = (k: CameraKey) => floorplans[k]?.bounds;
+    return {
+      'living-room': get('living-room'),
+      'kitchen': get('kitchen'),
+      'family-room': get('family-room'),
+    };
+  }, [floorplans]);
+
+  // Compute pixel sizes per camera based on bounds aspect; fixed width of 420 px
+  const sizeByKey = useMemo<Record<CameraKey, { w: number; h: number } | undefined>>(() => {
+    const W = 420;
+    const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+    const toSize = (b?: Bounds) => {
+      if (!b) return undefined;
+      const wx = (b.max_x ?? 0) - (b.min_x ?? 0);
+      const hz = (b.max_z ?? 0) - (b.min_z ?? 0);
+      if (!(isFinite(wx) && isFinite(hz)) || wx <= 0 || hz <= 0) return undefined;
+      const aspect = clamp(hz / wx, 0.5, 3.0);
+      const H = Math.round(W * aspect);
+      return { w: W, h: H };
+    };
+    return {
+      'living-room': toSize(boundsByKey['living-room']),
+      'kitchen': toSize(boundsByKey['kitchen']),
+      'family-room': toSize(boundsByKey['family-room']),
+    };
+  }, [boundsByKey]);
 
   useEffect(() => {
     if (!visible) {
       [canvLiving.current, canvKitchen.current, canvFamily.current].forEach(c => c?.getContext('2d')?.clearRect(0, 0, c.width, c.height));
       return;
     }
-    if (canvLiving.current) drawTrails(canvLiving.current, 'living-room', store, colorForTrack);
-    // For kitchen, render trails using their native values and dynamic scaling; canvas size matches 30'x18' aspect
-    if (canvKitchen.current) drawTrails(canvKitchen.current, 'kitchen', store, colorForTrack);
-    if (canvFamily.current) drawTrails(canvFamily.current, 'family-room', store, colorForTrack);
-  });
+    const drawFor = (cam: CameraKey, ref: React.RefObject<HTMLCanvasElement>) => {
+      const canvas = ref.current;
+      const size = sizeByKey[cam];
+      const b = boundsByKey[cam];
+      const useWorld = !!worldUsage[cam];
+      if (!canvas || !size || !b) return; // fail-fast: require bounds for rendering
+      // Apply size
+      if (canvas.width !== size.w) canvas.width = size.w;
+      if (canvas.height !== size.h) canvas.height = size.h;
+      // Draw using fixed viewport from bounds; invertY for z-forward
+      drawTrails(canvas, cam, store, colorForTrack, {
+        xMin: Number(b.min_x ?? 0),
+        xMax: Number(b.max_x ?? 0),
+        yMin: Number(b.min_z ?? 0),
+        yMax: Number(b.max_z ?? 0),
+        invertY: true,
+        drawCameraMarker: useWorld,
+      });
+    };
+    drawFor('living-room', canvLiving);
+    drawFor('kitchen', canvKitchen);
+    drawFor('family-room', canvFamily);
+  }, [visible, store, boundsByKey, sizeByKey, worldUsage]);
 
-  const renderRow = (cam: CameraKey, ref: React.RefObject<HTMLCanvasElement>) => (
-    <div className="vstack panel card">
-      <div className="card-title">Top‑Down • {cameraLabel(cam)}</div>
-      <div className="map-wrap">
-        <canvas
-          className="map"
-          ref={ref}
-          width={420}
-          height={
-            cam === 'kitchen' ? 252 :
-            cam === 'family-room' ? 420 :
-            280
-          }
-        />
+  const renderRow = (cam: CameraKey, ref: React.RefObject<HTMLCanvasElement>) => {
+    const size = sizeByKey[cam];
+    const b = boundsByKey[cam];
+    if (!size || !b) return null; // fail-fast: do not render without bounds
+    return (
+      <div className="vstack panel card">
+        <div className="card-title">Top‑Down • {cameraLabel(cam)}</div>
+        <div className="map-wrap">
+          <canvas
+            className="map"
+            ref={ref}
+            width={size.w}
+            height={size.h}
+            style={{ width: `${size.w}px`, height: `${size.h}px` }}
+          />
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   if (!visible) return null;
 


### PR DESCRIPTION
Size top-down map canvases by MapAnything room bounds to accurately reflect room proportions and fail-fast if bounds are unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-fef8c426-a7fd-433d-a13f-dfe4d7092f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fef8c426-a7fd-433d-a13f-dfe4d7092f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

