### PR TITLE
Fix python memory and segmentation faults

### DIFF
--- a/deepstream_video_pipeline.py
+++ b/deepstream_video_pipeline.py
@@ -27,7 +27,6 @@ import time
 import queue
 import json
 import ctypes
-import json
 import tempfile
 from collections import defaultdict, deque
 

--- a/deepstream_video_pipeline.py
+++ b/deepstream_video_pipeline.py
@@ -27,6 +27,7 @@ import time
 import queue
 import json
 import ctypes
+import json
 import tempfile
 from collections import defaultdict, deque
 
@@ -71,6 +72,38 @@ def _alloc_display_text(text: Optional[str]) -> ctypes.c_char_p:
     encoded = text.encode("utf-8")
     ptr = _glib.g_strdup(encoded)
     return ctypes.cast(ptr, ctypes.c_char_p)
+
+
+def _safe_cstring_from_ptr(ptr_val: int) -> Optional[str]:
+    """Best-effort, bounded read of C char* into Python str.
+
+    Attempts pyds.get_string when available, otherwise falls back to a bounded
+    ctypes.string_at to reduce risk of runaway reads. Returns None on failure.
+    """
+    try:
+        if not ptr_val:
+            return None
+        # Prefer pyds.get_string if available in this environment
+        try:
+            cptr = ctypes.cast(ctypes.c_void_p(ptr_val), ctypes.c_char_p)
+            getter = getattr(pyds, "get_string", None)
+            if callable(getter):
+                s = getter(cptr)  # type: ignore[misc]
+                if isinstance(s, str):
+                    return s
+        except Exception:
+            # Fall through to bounded raw read
+            pass
+
+        # Bounded raw read with a sane cap to minimize fault surface
+        MAX_READ = 1 << 20  # 1 MiB cap
+        raw = ctypes.string_at(ptr_val, MAX_READ)
+        nul = raw.find(b"\x00")
+        if nul != -1:
+            raw = raw[:nul]
+        return raw.decode("utf-8", "ignore")
+    except Exception:
+        return None
 
 # Local imports
 from websocket_server import WebSocketServer  # noqa: E402
@@ -2667,7 +2700,9 @@ class DeepStreamVideoPipeline:
                     data_ptr = ctypes.cast(user_meta.user_meta_data, ctypes.c_void_p).value
                     if data_ptr:
                         try:
-                            raw = ctypes.string_at(data_ptr).decode("utf-8", "ignore").rstrip("\x00")
+                            raw = _safe_cstring_from_ptr(int(data_ptr))
+                            if not raw:
+                                raise ValueError("empty payload")
                             payload = json.loads(raw)
                             if isinstance(payload, dict) and "mde" in payload:
                                 entry = payload["mde"]


### PR DESCRIPTION
Replace unbounded `ctypes.string_at` read with a safe, bounded C-string reader to prevent memory faults.

The original `ctypes.string_at(data_ptr)` could read beyond allocated memory if `data_ptr` didn't point to a null-terminated string or if the string was malformed, leading to segmentation faults or "free(): invalid size" errors. The new `_safe_cstring_from_ptr` function uses `pyds.get_string` if available (which is safer as it's DeepStream-aware) or falls back to a `ctypes.string_at` with a maximum read limit, significantly reducing the risk of out-of-bounds reads and associated crashes. This change hardens the DeepStream pipeline against memory corruption without altering its intended functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-3675e051-745a-4770-8c01-9d2b18e693ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3675e051-745a-4770-8c01-9d2b18e693ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

